### PR TITLE
fix: add missing haskellLib input attribute

### DIFF
--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -17,7 +17,7 @@ inputs:
   # Extra tools to include in the shell. This is a function that takes nixpkgs
   # as the argument and returns a list of packages.
 , extraTools ? nixpkgs: [ ]
-, haskellPackagesOverride ? { compilerName, final, prev }: { }
+, haskellPackagesOverride ? { compilerName, haskellLib, final, prev }: { }
 }:
 inputs.flake-utils.lib.eachDefaultSystem (system:
   let


### PR DESCRIPTION
I attempted a `flake update` on the https://github.com/bellroy/timeline library but was failing on: 

```
error: anonymous function at /nix/store/dykasgnbmjcxxfa5m4xsg297yhgrnxx3-source/haskell-project.nix:20:
29 called with unexpected argument 'haskellLib'

       at /nix/store/dykasgnbmjcxxfa5m4xsg297yhgrnxx3-source/haskell-project.nix:39:35:

           38|               );
           39|           overridenDependencies = haskellPackagesOverride {
             |                                   ^
           40|             inherit compilerName;
```

Adding the attribute to the input solve this, though I'm not 100% sure that this is the right fix. Would love some feedback.