### PR TITLE
Remove haskell package sets from shell

### DIFF
--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -1,101 +1,36 @@
 inputs:
 {
-  # A list of packages in the project.
-  # Example:
-  #   [
-  #     {
-  #       name = "timeline";
-  #       path = ./package.nix;
-  #     }
-  #   ]
-  cabalPackages
   # A list of compiler versions supported in the project.
   # Valid values are keys of haskell.compiler in nixpkgs.
-, supportedCompilers
+  supportedCompilers
   # Default compiler version to choose. Must be one of the supportedCompilers.
 , defaultCompiler ? builtins.head supportedCompilers
   # Extra tools to include in the shell. This is a function that takes nixpkgs
   # as the argument and returns a list of packages.
 , extraTools ? nixpkgs: [ ]
-, haskellPackagesOverride ? { compilerName, haskellLib, final, prev }: { }
 }:
 inputs.flake-utils.lib.eachDefaultSystem (system:
   let
     nixpkgs = import inputs.nixpkgs { inherit system; };
 
-    makePackageSet = compilerName: haskellPackages: haskellPackages.override {
-      overrides = final: prev:
-        let
-          projectPackages =
-            builtins.listToAttrs
-              (
-                builtins.map
-                  (cabalPackage: {
-                    name = cabalPackage.name;
-                    value = prev.callPackage cabalPackage.path { };
-                  })
-                  cabalPackages
-              );
-          overridenDependencies = haskellPackagesOverride {
-            inherit compilerName;
-            haskellLib = nixpkgs.haskell.lib;
-            inherit final;
-            inherit prev;
-          };
-        in
-        projectPackages // overridenDependencies;
-    };
-
     essentialTools = with nixpkgs; [
       cabal-install
+      cabal2nix
+      haskell-ci
+      haskellPackages.cabal-fmt
+      haskellPackages.haskell-language-server
       hlint
       nixpkgs-fmt
       ormolu
-      haskellPackages.cabal-fmt
-      cabal2nix
-      haskell-ci
-      miniserve
     ] ++ extraTools nixpkgs;
 
-    makeShell = compilerName: haskellPackages: (makePackageSet compilerName haskellPackages).shellFor {
-      packages = p: builtins.map (cabalPackage: p.${cabalPackage.name}) cabalPackages;
-      withHoogle = true;
-      buildInputs = essentialTools ++ [
-        nixpkgs.haskellPackages.haskell-language-server
+    makeShell = compilerName: nixpkgs.mkShell {
+      packages = essentialTools ++ [
+        nixpkgs.haskell.compiler.${compilerName}
       ];
-    };
-
-    lightShell = nixpkgs.mkShell {
-      packages = essentialTools ++ [ nixpkgs.ghc ];
     };
   in
   {
-    packages =
-      let packagesWithoutDefault =
-        builtins.listToAttrs
-          (
-            builtins.concatMap
-              (compilerName:
-                let pkgSet = makePackageSet compilerName nixpkgs.haskell.packages.${compilerName};
-                in
-                builtins.map
-                  (cabalPackage: {
-                    name = "${compilerName}-${cabalPackage.name}";
-                    value = pkgSet.${cabalPackage.name};
-                  })
-                  cabalPackages
-              )
-              supportedCompilers
-          );
-      in
-      packagesWithoutDefault // {
-        default = nixpkgs.runCommand "aggregate"
-          {
-            buildInputs = builtins.map (name: packagesWithoutDefault.${name})
-              (builtins.attrNames packagesWithoutDefault);
-          } "touch $out";
-      };
-
     devShells =
       let devShellsWithoutDefault =
         builtins.listToAttrs
@@ -103,13 +38,12 @@ inputs.flake-utils.lib.eachDefaultSystem (system:
             builtins.map
               (compilerName: {
                 name = compilerName;
-                value = makeShell compilerName nixpkgs.haskell.packages.${compilerName};
+                value = makeShell compilerName;
               })
               supportedCompilers
           ); in
       devShellsWithoutDefault // {
         default = devShellsWithoutDefault.${defaultCompiler};
-        light = lightShell;
       };
   }
 )


### PR DESCRIPTION
Because the Haskell infrastructure in nixpkgs selects one version of each package, it can be difficult to make developer shells that work well across multiple GHC releases. This forces us to maintain a hand-curated set of overrides in many of our projects: a lot of work for relatively little benefit here.

So, restrict the `devShells` to provide only GHC and cabal, and let `cabal` fetch the appropriate dependencies for each compiler. It is often the case that `cabal` wants to fetch alternate versions of libraries anyway, unless you waste more time in a delicate balancing act of selecting library versions that work for all supported compilers.