### PR TITLE
haskell-project.nix: add zlib to shells (and option for others)

### DIFF
--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -5,34 +5,40 @@ inputs:
   supportedCompilers
   # Default compiler version to choose. Must be one of the supportedCompilers.
 , defaultCompiler ? builtins.head supportedCompilers
+  # Additional haskell packages whose deps should be included in the
+  # shell. We want cabal to provide most packages, so only list
+  # packages with native dependencies. That ensures the provided GHC
+  # can find necessary native libraries on NixOS.
+, haskellFfiPackages ? hpkgs: [ ]
   # Extra tools to include in the shell. This is a function that takes nixpkgs
   # as the argument and returns a list of packages.
 , extraTools ? nixpkgs: [ ]
 }:
 inputs.flake-utils.lib.eachDefaultSystem (system:
-  let
-    nixpkgs = import inputs.nixpkgs { inherit system; };
+let
+  nixpkgs = import inputs.nixpkgs { inherit system; };
 
-    essentialTools = with nixpkgs; [
-      cabal-install
-      cabal2nix
-      haskell-ci
-      haskellPackages.cabal-fmt
-      haskellPackages.haskell-language-server
-      hlint
-      nixpkgs-fmt
-      ormolu
-    ] ++ extraTools nixpkgs;
+  essentialTools = with nixpkgs; [
+    cabal-install
+    cabal2nix
+    haskell-ci
+    haskellPackages.cabal-fmt
+    haskellPackages.haskell-language-server
+    hlint
+    nixpkgs-fmt
+    ormolu
+  ] ++ extraTools nixpkgs;
 
-    makeShell = compilerName: nixpkgs.mkShell {
-      packages = essentialTools ++ [
-        nixpkgs.haskell.compiler.${compilerName}
-      ];
-    };
-  in
-  {
-    devShells =
-      let devShellsWithoutDefault =
+  makeShell = compilerName: nixpkgs.haskell.packages.${compilerName}.shellFor {
+    # Provide zlib by default because anything non-trivial will depend on it.
+    packages = hpkgs: [ hpkgs.zlib ] ++ haskellFfiPackages hpkgs;
+    nativeBuildInputs = [ essentialTools ];
+  };
+in
+{
+  devShells =
+    let
+      devShellsWithoutDefault =
         builtins.listToAttrs
           (
             builtins.map
@@ -41,9 +47,10 @@ inputs.flake-utils.lib.eachDefaultSystem (system:
                 value = makeShell compilerName;
               })
               supportedCompilers
-          ); in
-      devShellsWithoutDefault // {
-        default = devShellsWithoutDefault.${defaultCompiler};
-      };
-  }
+          );
+    in
+    devShellsWithoutDefault // {
+      default = devShellsWithoutDefault.${defaultCompiler};
+    };
+}
 )


### PR DESCRIPTION
On NixOS, GHC will fail to find native libraries unless packages which use them are plumbed into its package set. This usually manifests in a failure to find `zlib`, because it's so ubiquitous. Add it to the shell and provide another function argument for other native libs we might need.