### PR TITLE
Haskell ci from git

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,13 +34,29 @@
         "type": "github"
       }
     },
+    "haskell-ci": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720460048,
+        "narHash": "sha256-k3YCC4RIVxocXYbNHkmGYvlsoFlv5XZmk1DYfVQMaPs=",
+        "owner": "haskell-ci",
+        "repo": "haskell-ci",
+        "rev": "5e5b27d74f90e73905c4f56f4aefe521f97879f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell-ci",
+        "repo": "haskell-ci",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719082008,
-        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "lastModified": 1724047581,
+        "narHash": "sha256-BypLrnMS2QvvdVhwWixppTOM3fLPC8eyJse0BNSbbfI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "rev": "e9b5094b8f6e06a46f9f53bb97a9573b7cedf2a2",
         "type": "github"
       },
       "original": {
@@ -53,6 +69,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
+        "haskell-ci": "haskell-ci",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -34,6 +34,27 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "haskell-ci": {
       "flake": false,
       "locked": {
@@ -52,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724047581,
-        "narHash": "sha256-BypLrnMS2QvvdVhwWixppTOM3fLPC8eyJse0BNSbbfI=",
+        "lastModified": 1724177844,
+        "narHash": "sha256-G7Mf9uN9m8FimeP3eMHu/dOC4QS8QAzo0h4ZIlDHcCA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9b5094b8f6e06a46f9f53bb97a9573b7cedf2a2",
+        "rev": "d13fa5a45a34e7c8be33474f58003914430bdc5a",
         "type": "github"
       },
       "original": {
@@ -65,12 +86,51 @@
         "type": "indirect"
       }
     },
-    "root": {
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1724159077,
+        "narHash": "sha256-AddE0u6WbA5R7uxumw1Ka0oG5dv3cTtN0ppO/M/e0cg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "1064a45e81a4e19cda98741b71219d9f4f136900",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
         "flake-utils": "flake-utils",
         "haskell-ci": "haskell-ci",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,10 @@
   # Use 'nix flake show' to discover the structure of the output.
   # Multiple versions of compiler is supported.
   inputs = {
+    haskell-ci = {
+      url = "github:haskell-ci/haskell-ci";
+      flake = false;
+    };
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,15 @@
   # Use 'nix flake show' to discover the structure of the output.
   # Multiple versions of compiler is supported.
   inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
     haskell-ci = {
       url = "github:haskell-ci/haskell-ci";
       flake = false;
     };
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
+    pre-commit-hooks = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:cachix/pre-commit-hooks.nix";
     };
   };
 

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -18,6 +18,25 @@ inputs.flake-utils.lib.eachDefaultSystem (system:
 let
   nixpkgs = import inputs.nixpkgs { inherit system; };
 
+  haskell-ci =
+    let
+      # Hopefully many of these overrides become redundant in future
+      # dependency update cycles, as the default version in
+      # `nixpkgs.haskellPackages` become compatible with `haskell-ci`.
+      haskellPackages = nixpkgs.haskellPackages.override {
+        overrides = hfinal: hprev: with nixpkgs.haskell.lib.compose; {
+          aeson = doJailbreak hprev.aeson_2_2_2_0;
+          base-compat = hprev.base-compat_0_14_0;
+          haskell-ci = doJailbreak (hprev.callCabal2nix "haskell-ci" inputs.haskell-ci { });
+          lattices = doJailbreak hprev.lattices;
+          primitive = dontCheck hprev.primitive_0_9_0_0;
+          ShellCheck = hprev.ShellCheck_0_9_0;
+          time-compat = doJailbreak hprev.time-compat;
+        };
+      };
+    in
+    haskellPackages.haskell-ci;
+
   essentialTools = with nixpkgs; [
     cabal-install
     cabal2nix


### PR DESCRIPTION
The latest release of `haskell-ci` on Hackage generates broken configs by default, and doesn't know about recent GHC. Also add pre-commit hooks while I'm here.

Annoyingly, this means we'll have to do more building when entering a dev shell, at least until the library ecosystem (as captured in nixpkgs) catches up. I'll work on adding Hydra support for foss repos so we can cache them for at least ourselves.