### PR TITLE
Pin aeson using `callHackage`

### DIFF
--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -27,7 +27,7 @@ let
       # `nixpkgs.haskellPackages` become compatible with `haskell-ci`.
       haskellPackages = nixpkgs.haskellPackages.override {
         overrides = hfinal: hprev: with nixpkgs.haskell.lib.compose; {
-          aeson = doJailbreak hprev.aeson_2_2_2_0;
+          aeson = doJailbreak (hprev.callHackage "aeson" "2.2.2.0" { });
           base-compat = hprev.base-compat_0_14_0;
           haskell-ci = doJailbreak (hprev.callCabal2nix "haskell-ci" inputs.haskell-ci { });
           lattices = doJailbreak hprev.lattices;


### PR DESCRIPTION
For some reason, different Haskell packages have different pinned aeson versions in their hackage package set. Just get it via `callHackage` until things settle down.