### PR TITLE
20241210 dependency update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733656523,
-        "narHash": "sha256-w0FXPfpGhOihoJDiwMsyN1EzpsXi2F8VQ+NVZQSMtys=",
+        "lastModified": 1733686850,
+        "narHash": "sha256-NQEO/nZWWGTGlkBWtCs/1iF1yl2lmQ1oY/8YZrumn3I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "93dc9803a1ee435e590b02cde9589038d5cc3a4e",
+        "rev": "dd51f52372a20a93c219e8216fe528a648ffcbf4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     "haskell-ci": {
       "flake": false,
       "locked": {
-        "lastModified": 1720460048,
-        "narHash": "sha256-k3YCC4RIVxocXYbNHkmGYvlsoFlv5XZmk1DYfVQMaPs=",
+        "lastModified": 1733162672,
+        "narHash": "sha256-sM4nbl1CYojEcqah7Hl9x3p8ilr0iafVOQmNglRjEtI=",
         "owner": "haskell-ci",
         "repo": "haskell-ci",
-        "rev": "5e5b27d74f90e73905c4f56f4aefe521f97879f0",
+        "rev": "ec21b78d581f311e55dcd5326c9459a0bdc30b76",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1733656523,
+        "narHash": "sha256-w0FXPfpGhOihoJDiwMsyN1EzpsXi2F8VQ+NVZQSMtys=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "93dc9803a1ee435e590b02cde9589038d5cc3a4e",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728778939,
-        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
+        "lastModified": 1733665616,
+        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
+        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
         "type": "github"
       },
       "original": {

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -26,24 +26,6 @@ let
     let
       nixpkgs = import inputs.nixpkgs { inherit system; };
 
-      haskell-ci =
-        let
-          # Hopefully many of these overrides become redundant in future
-          # dependency update cycles, as the default version in
-          # `nixpkgs.haskellPackages` become compatible with `haskell-ci`.
-          haskellPackages = nixpkgs.haskellPackages.override {
-            overrides = hfinal: hprev: with nixpkgs.haskell.lib.compose; {
-              aeson = doJailbreak hprev.aeson;
-              base-compat = hprev.base-compat_0_14_0;
-              base-compat-batteries = hprev.base-compat-batteries_0_14_0;
-              haskell-ci = doJailbreak (hprev.callCabal2nix "haskell-ci" inputs.haskell-ci { });
-              ShellCheck = hprev.ShellCheck_0_9_0;
-              time-compat = doJailbreak hprev.time-compat;
-            };
-          };
-        in
-        haskellPackages.haskell-ci;
-
       checks.pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
         inherit src;
         hooks = {
@@ -57,7 +39,6 @@ let
       essentialTools = with nixpkgs; [
         cabal-install
         cabal2nix
-        haskell-ci
         haskellPackages.cabal-fmt
         haskellPackages.ghcid
         haskellPackages.haskell-language-server


### PR DESCRIPTION
This pull request includes significant changes to the `haskell-project.nix` file, focusing on simplifying the dependency management by removing custom overrides and redundant packages. The most important changes include the removal of the `haskell-ci` package and its associated overrides.

* `nix flake update`
* Removed custom overrides for several Haskell packages, including `aeson`, `base-compat`, `base-compat-batteries`, `ShellCheck`, and `time-compat`, as well as the `haskell-ci` package itself.
* Removed `haskell-ci` from the list of essential tools, streamlining the toolset defined in the project.