### PR TITLE
Rename to git hooks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,32 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1740915799,
+        "narHash": "sha256-JvQvtaphZNmeeV+IpHgNdiNePsIpHD5U/7QN5AeY44A=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "42b1ba089d2034d910566bf6b40830af6b8ec732",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -70,33 +92,11 @@
         "type": "indirect"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1740915799,
-        "narHash": "sha256-JvQvtaphZNmeeV+IpHgNdiNePsIpHD5U/7QN5AeY44A=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "42b1ba089d2034d910566bf6b40830af6b8ec732",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,9 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
-    pre-commit-hooks = {
+    git-hooks = {
       inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:cachix/pre-commit-hooks.nix";
+      url = "github:cachix/git-hooks.nix";
     };
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,8 +10,5 @@
     };
   };
 
-  outputs = inputs:
-    {
-      lib.haskellProject = import ./haskell-project.nix inputs;
-    };
+  outputs = inputs: { lib.haskellProject = import ./haskell-project.nix inputs; };
 }

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -1,28 +1,31 @@
 inputs:
 {
   # Source directory of the project using this flake.
-  src
+  src,
   # A list of compiler versions supported in the project.
   # Valid values are keys of haskell.compiler in nixpkgs.
-, supportedCompilers
+  supportedCompilers,
   # Default compiler version to choose. Must be one of the supportedCompilers.
-, defaultCompiler ? builtins.head supportedCompilers
+  defaultCompiler ? builtins.head supportedCompilers,
   # Additional haskell packages whose deps should be included in the
   # shell. We want cabal to provide most packages, so only list
   # packages with native dependencies. That ensures the provided GHC
   # can find necessary native libraries on NixOS.
-, haskellFfiPackages ? hpkgs: [ ]
+  haskellFfiPackages ? hpkgs: [ ],
   # Extra tools to include in the shell. This is a function that takes nixpkgs
   # as the argument and returns a list of packages.
-, extraTools ? nixpkgs: [ ]
+  extraTools ? nixpkgs: [ ],
 }:
 let
   evalPkgs = import inputs.nixpkgs { system = "x86_64-linux"; };
-  systems =
-    with inputs.flake-utils.lib.system;
-    [ aarch64-darwin x86_64-darwin x86_64-linux ];
+  systems = with inputs.flake-utils.lib.system; [
+    aarch64-darwin
+    x86_64-darwin
+    x86_64-linux
+  ];
 
-  perSystem = inputs.flake-utils.lib.eachSystem systems (system:
+  perSystem = inputs.flake-utils.lib.eachSystem systems (
+    system:
     let
       nixpkgs = import inputs.nixpkgs { inherit system; };
 
@@ -36,59 +39,53 @@ let
         };
       };
 
-      essentialTools = with nixpkgs; [
-        cabal-install
-        cabal2nix
-        haskellPackages.cabal-fmt
-        haskellPackages.ghcid
-        haskellPackages.haskell-language-server
-        hlint
-        nixpkgs-fmt
-        ormolu
-      ] ++ extraTools nixpkgs;
+      essentialTools =
+        with nixpkgs;
+        [
+          cabal-install
+          cabal2nix
+          haskellPackages.cabal-fmt
+          haskellPackages.ghcid
+          haskellPackages.haskell-language-server
+          hlint
+          nixpkgs-fmt
+          ormolu
+        ]
+        ++ extraTools nixpkgs;
 
-      makeShell = compilerName: nixpkgs.haskell.packages.${compilerName}.shellFor {
-        inherit (checks.pre-commit-check) shellHook;
+      makeShell =
+        compilerName:
+        nixpkgs.haskell.packages.${compilerName}.shellFor {
+          inherit (checks.pre-commit-check) shellHook;
 
-        # Provide zlib by default because anything non-trivial will depend on it.
-        packages = hpkgs: [ hpkgs.zlib ] ++ haskellFfiPackages hpkgs;
-        nativeBuildInputs = [ essentialTools ]
-          ++ checks.pre-commit-check.enabledPackages;
-      };
+          # Provide zlib by default because anything non-trivial will depend on it.
+          packages = hpkgs: [ hpkgs.zlib ] ++ haskellFfiPackages hpkgs;
+          nativeBuildInputs = [ essentialTools ] ++ checks.pre-commit-check.enabledPackages;
+        };
     in
     {
       devShells =
         let
-          devShellsWithoutDefault =
-            builtins.listToAttrs
-              (
-                builtins.map
-                  (compilerName: {
-                    name = compilerName;
-                    value = makeShell compilerName;
-                  })
-                  supportedCompilers
-              );
+          devShellsWithoutDefault = builtins.listToAttrs (
+            builtins.map (compilerName: {
+              name = compilerName;
+              value = makeShell compilerName;
+            }) supportedCompilers
+          );
         in
-        devShellsWithoutDefault // {
-          default = devShellsWithoutDefault.${defaultCompiler};
-        };
+        devShellsWithoutDefault // { default = devShellsWithoutDefault.${defaultCompiler}; };
     }
   );
 
   hydraJobs = {
-    aggregate = evalPkgs.runCommand "aggregate"
-      {
-        _hydraAggregate = true;
-        constituents = builtins.concatMap
-          (system:
-            builtins.map
-              (ghc: "devShells.${system}.${ghc}")
-              supportedCompilers ++ [ "devShells.${system}.default" ]
-          )
-          systems;
-      }
-      "touch $out";
+    aggregate = evalPkgs.runCommand "aggregate" {
+      _hydraAggregate = true;
+      constituents = builtins.concatMap (
+        system:
+        builtins.map (ghc: "devShells.${system}.${ghc}") supportedCompilers
+        ++ [ "devShells.${system}.default" ]
+      ) systems;
+    } "touch $out";
   } // { inherit (perSystem) devShells; };
 in
 perSystem // { inherit hydraJobs; }

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -31,7 +31,7 @@ let
         hooks = {
           cabal-fmt.enable = true;
           hlint.enable = true;
-          nixpkgs-fmt.enable = true;
+          nixfmt-rfc-style.enable = true;
           ormolu.enable = true;
         };
       };

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -26,7 +26,7 @@ let
     let
       nixpkgs = import inputs.nixpkgs { inherit system; };
 
-      checks.pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
+      checks.pre-commit-check = inputs.git-hooks.lib.${system}.run {
         inherit src;
         hooks = {
           cabal-fmt.enable = true;


### PR DESCRIPTION
Cachix changed the name of the upstream repo; let's follow that. And switch to `nixfmt-rfc-style` formatter like we use in the monorepo.