### PR TITLE
Provide install-pre-commit-checks app

### DIFF
--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -66,9 +66,6 @@ let
           packages = hpkgs: [ hpkgs.zlib ] ++ haskellFfiPackages hpkgs;
           nativeBuildInputs = [ essentialTools ] ++ checks.pre-commit-check.enabledPackages;
         };
-      install-pre-commit-checks = pkgs.writeShellScriptBin "install-pre-commit-checks" ''
-        ${checks.pre-commit-check.shellHook}
-      '';
     in
     {
       devShells =
@@ -82,9 +79,12 @@ let
         in
         devShellsWithoutDefault // { default = devShellsWithoutDefault.${defaultCompiler}; };
 
-      apps.install-pre-commit-checks = {
-        type = "app";
-        program = "${install-pre-commit-checks}/bin/install-pre-commit-checks";
+      packages.install-pre-commit-checks = pkgs.writeShellScriptBin "install-pre-commit-checks" ''
+        ${checks.pre-commit-check.shellHook}
+      '';
+
+      apps.install-pre-commit-checks = inputs.flake-utils.lib.mkApp {
+        drv = inputs.self.packages.${system}.install-pre-commit-checks;
       };
     }
   );

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -66,6 +66,10 @@ let
           packages = hpkgs: [ hpkgs.zlib ] ++ haskellFfiPackages hpkgs;
           nativeBuildInputs = [ essentialTools ] ++ checks.pre-commit-check.enabledPackages;
         };
+
+      install-pre-commit-checks = pkgs.writeShellScriptBin "install-pre-commit-checks" ''
+        ${checks.pre-commit-check.shellHook}
+      '';
     in
     {
       devShells =
@@ -79,12 +83,10 @@ let
         in
         devShellsWithoutDefault // { default = devShellsWithoutDefault.${defaultCompiler}; };
 
-      packages.install-pre-commit-checks = pkgs.writeShellScriptBin "install-pre-commit-checks" ''
-        ${checks.pre-commit-check.shellHook}
-      '';
+      packages.install-pre-commit-checks = install-pre-commit-checks;
 
       apps.install-pre-commit-checks = inputs.flake-utils.lib.mkApp {
-        drv = inputs.self.packages.${system}.install-pre-commit-checks;
+        drv = install-pre-commit-checks;
       };
     }
   );

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -66,6 +66,9 @@ let
           packages = hpkgs: [ hpkgs.zlib ] ++ haskellFfiPackages hpkgs;
           nativeBuildInputs = [ essentialTools ] ++ checks.pre-commit-check.enabledPackages;
         };
+      install-pre-commit-checks = pkgs.writeShellScriptBin "install-pre-commit-checks" ''
+        ${checks.pre-commit-check.shellHook}
+      '';
     in
     {
       devShells =
@@ -78,6 +81,11 @@ let
           );
         in
         devShellsWithoutDefault // { default = devShellsWithoutDefault.${defaultCompiler}; };
+
+      apps.install-pre-commit-checks = {
+        type = "app";
+        program = "${install-pre-commit-checks}/bin/install-pre-commit-checks";
+      };
     }
   );
 


### PR DESCRIPTION
So that we can use `nix run .#install-pre-commit-checks` to install git hooks without needing to enter Nix shells.