### PR TITLE
chore: dependency update day 2026-06-09

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,16 +79,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780815147,
-        "narHash": "sha256-FSDVygpoXrYLH5ZYcqjNkCZzzQrRYZW3awA9vDgb60g=",
+        "lastModified": 1780773863,
+        "narHash": "sha256-t0AXyb11HJHwyRkCed8y15unmgwVlbgcIEVdV1XxYvA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a681e663d65ff3b0c636df6c7cfbad31e1ed311",
+        "rev": "20872773637de0b44f7ac04cde2098db1286e6d5",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   # Multiple versions of compiler is supported.
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "nixpkgs/nixpkgs-25.11-darwin";
+    nixpkgs.url = "nixpkgs/nixpkgs-26.05-darwin";
     git-hooks = {
       inputs.nixpkgs.follows = "nixpkgs";
       url = "github:cachix/git-hooks.nix";


### PR DESCRIPTION
Following instructions for updating unliftio-servant-server - this ought to be using `nixpkgs-26.05-darwin` and no longer 25.11. Assuming no breaking changes ...

New warnings to resolve (acquired from doing a `nix develop` inside `unliftio-servant-server` with its `bellroy-nix-foss` input pointing to this branch)
```
evaluation warning: Dependency of package 'ghc-shell-for-zlib-0.7.1.1-0' uses a nested list in attribute 'nativeBuildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
```

- updated nixpkgs branch

flake.lock: Update

Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9a681e663d65ff3b0c636df6c7cfbad31e1ed311?narHash=sha256-FSDVygpoXrYLH5ZYcqjNkCZzzQrRYZW3awA9vDgb60g%3D' (2026-06-07)
  → 'github:NixOS/nixpkgs/20872773637de0b44f7ac04cde2098db1286e6d5?narHash=sha256-t0AXyb11HJHwyRkCed8y15unmgwVlbgcIEVdV1XxYvA%3D' (2026-06-06)